### PR TITLE
Support Altcha  v1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.1"
           - "8.2"
           - "8.3"
           - "8.4"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     }
   ],
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.2",
     "symfony/form": "^6.4|^7.0",
     "symfony/framework-bundle": "^6.4|^7.0",
     "symfony/http-client": "^6.4|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "symfony/validator": "^6.4|^7.0",
     "symfony/twig-bundle": "^6.4|^7.0",
     "symfony/translation": "^6.4|^7.0",
-    "altcha-org/altcha": "^0.1"
+    "altcha-org/altcha": "^1.1.2"
   },
   "autoload": {
     "psr-4": {

--- a/src/Service/ChallengeResolver.php
+++ b/src/Service/ChallengeResolver.php
@@ -18,12 +18,11 @@ class ChallengeResolver implements ChallengeResolverInterface
 
     public function getChallenge(): Challenge
     {
-        $options = new ChallengeOptions([
-            'hmacKey' => $this->hmacKey,
-            'maxNumber' => 100000,
-            'expires' => (new \DateTime())->modify($this->expires),
-        ]);
+        $options = new ChallengeOptions(
+            maxNumber: 100000,
+            expires: (new \DateTime())->modify($this->expires),
+        );
 
-        return Altcha::createChallenge($options);
+        return (new Altcha($this->hmacKey))->createChallenge($options);
     }
 }

--- a/src/Validator/AltchaValidator.php
+++ b/src/Validator/AltchaValidator.php
@@ -21,7 +21,7 @@ final class AltchaValidator extends ConstraintValidator
     /**
      * Checks if the passed value is valid.
      *
-     * @param mixed      $altchaEncoded The value that should be validated
+     * @param mixed      $value         The value that should be validated
      * @param Constraint $constraint    The constraint for the validation
      */
     public function validate(mixed $value, Constraint $constraint): void

--- a/src/Validator/AltchaValidator.php
+++ b/src/Validator/AltchaValidator.php
@@ -24,23 +24,25 @@ final class AltchaValidator extends ConstraintValidator
      * @param mixed      $altchaEncoded The value that should be validated
      * @param Constraint $constraint    The constraint for the validation
      */
-    public function validate($altchaEncoded, Constraint $constraint): void
+    public function validate(mixed $value, Constraint $constraint): void
     {
         if (false === $this->enable) {
             return;
         }
 
-        if (!$altchaEncoded) {
+        if (!$value) {
             $request = $this->requestStack->getCurrentRequest();
-            $altchaEncoded = $request->request->get('altcha');
+            $value = $request?->request->get('altcha');
         }
-        if (!is_string($altchaEncoded)) {
+
+        if (!is_string($value)) {
             $this->context->buildViolation($constraint->message)
                 ->addviolation();
 
             return;
         }
-        $altchaJson = base64_decode($altchaEncoded, true);
+
+        $altchaJson = base64_decode($value, true);
         if (!is_string($altchaJson)) {
             $this->context->buildViolation($constraint->message)
                 ->addviolation();
@@ -49,7 +51,7 @@ final class AltchaValidator extends ConstraintValidator
         }
         $payload = json_decode($altchaJson, true, 512, JSON_THROW_ON_ERROR);
 
-        if (!Altcha::verifySolution($payload, $this->hmacKey, true)) {
+        if (!(new Altcha($this->hmacKey))->verifySolution($payload, true)) {
             $this->context->buildViolation($constraint->message)
                 ->addviolation();
         }

--- a/tests/Controller/HulutiAltchaChallengeControllerTest.php
+++ b/tests/Controller/HulutiAltchaChallengeControllerTest.php
@@ -16,14 +16,12 @@ class HulutiAltchaChallengeControllerTest extends KernelTestCase
 
     public function testChallenge()
     {
-
-        $challengeOptions = new ChallengeOptions([
-            'hmacKey' => 'test-key',
-            'maxNumber' => 100000,
-            'number' => 10,
-            'expires' => (new \DateTime())->modify("+1 day"),
-        ]);
-        $challenge = Altcha::createChallenge($challengeOptions);
+        $challengeOptions = new ChallengeOptions(
+            maxNumber: 100000,
+            expires: (new \DateTime())->modify("+1 day"),
+        );
+        $altcha = new Altcha('test-key');
+        $challenge = $altcha->createChallenge($challengeOptions);
 
         $challengeResolver = $this->createMock(ChallengeResolverInterface::class);
         $challengeResolver->method('getChallenge')->willReturn($challenge);
@@ -36,9 +34,9 @@ class HulutiAltchaChallengeControllerTest extends KernelTestCase
 
         $payload = json_decode($response->getContent(), true);
 
-        $payload['number'] = 10;
+        $payload['number'] = $challengeOptions->number;
 
-        $isValid = Altcha::verifySolution($payload, 'test-key');
+        $isValid = $altcha->verifySolution($payload);
 
         $this->assertTrue($isValid);
     }


### PR DESCRIPTION
Hi,
It's a some change to update the bundle to use the last stable release of php library altcha instead of the alpha/beta version.
The major change is now the Altcha library requires object and not use static function and use named parameters instead of array

Sorry for the last message, I had push it just before lost power.
Have a nice day