### PR TITLE
Add use_asset_mapper option to rely on importmap feature and not load script tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2025-06-03
+- Bump Altcha js lib to v2
+- Drop script tag if Asset Mapper is installed
+
 ## [1.3.0] - 2025-05-19
 - Bump Altcha PHP dependency to 1.x
 - Drop support for PHP 8.1

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@ init:
 	composer require --dev --working-dir=tools/php-cs-fixer friendsofphp/php-cs-fixer
 
 format:
-	tools/php-cs-fixer/vendor/bin/php-cs-fixer fix src
+	PHP_CS_FIXER_IGNORE_ENV=1 tools/php-cs-fixer/vendor/bin/php-cs-fixer fix src

--- a/config/services.yml
+++ b/config/services.yml
@@ -6,6 +6,7 @@ services:
       $enable: '%huluti_altcha.enable%'
       $floating: '%huluti_altcha.floating%'
       $useStimulus: '%huluti_altcha.use_stimulus%'
+      $useAssetMapper: '%huluti_altcha.use_asset_mapper%'
       $hideLogo: '%huluti_altcha.hide_logo%'
       $hideFooter: '%huluti_altcha.hide_footer%'
       $jsPath: '%huluti_altcha.js_path%'

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -23,6 +23,7 @@ class Configuration implements ConfigurationInterface
             ->booleanNode('enable')->defaultTrue()->end()
             ->booleanNode('floating')->defaultFalse()->end()
             ->booleanNode('use_stimulus')->defaultNull()->end()
+            ->booleanNode('use_asset_mapper')->defaultNull()->end()
             ->booleanNode('hide_logo')->defaultFalse()->end()
             ->booleanNode('hide_footer')->defaultFalse()->end()
             ->scalarNode('altcha_js_path')->defaultValue('https://eu.altcha.org/js/latest/altcha.min.js')->end()

--- a/src/DependencyInjection/HulutiAltchaExtension.php
+++ b/src/DependencyInjection/HulutiAltchaExtension.php
@@ -39,11 +39,14 @@ class HulutiAltchaExtension extends Extension implements PrependExtensionInterfa
         $container->setParameter('huluti_altcha.hide_footer', $config['hide_footer']);
         $container->setParameter('huluti_altcha.js_path', $config['altcha_js_path']);
 
+        $assetMapperInstalled = interface_exists(AssetMapperInterface::class);
+        $container->setParameter('huluti_altcha.use_asset_mapper', $assetMapperInstalled);
+
         $useStimulus = $config['use_stimulus'];
         if (null === $useStimulus) {
             $bundles = $container->getParameter('kernel.bundles');
             assert(is_array($bundles));
-            $useStimulus = in_array(StimulusBundle::class, $bundles, true) && interface_exists(AssetMapperInterface::class);
+            $useStimulus = in_array(StimulusBundle::class, $bundles, true) && $assetMapperInstalled;
         }
 
         $container->setParameter('huluti_altcha.use_stimulus', $useStimulus);

--- a/src/Type/AltchaType.php
+++ b/src/Type/AltchaType.php
@@ -18,6 +18,7 @@ class AltchaType extends AbstractType
         private readonly bool $enable,
         private readonly bool $floating,
         private readonly bool $useStimulus,
+        private readonly bool $useAssetMapper,
         private readonly bool $hideLogo,
         private readonly bool $hideFooter,
         private readonly string $jsPath,
@@ -50,6 +51,7 @@ class AltchaType extends AbstractType
         $view->vars['enable'] = $this->enable;
         $view->vars['floating'] = $options['floating'] ?? $this->floating;
         $view->vars['use_stimulus'] = $this->useStimulus;
+        $view->vars['use_asset_mapper'] = $this->useAssetMapper;
         $view->vars['hide_logo'] = $options['hide_logo'] ?? $this->hideLogo;
         $view->vars['hide_footer'] = $options['hide_footer'] ?? $this->hideFooter;
         $view->vars['js_path'] = $this->jsPath;

--- a/src/Validator/AltchaValidator.php
+++ b/src/Validator/AltchaValidator.php
@@ -21,8 +21,8 @@ final class AltchaValidator extends ConstraintValidator
     /**
      * Checks if the passed value is valid.
      *
-     * @param mixed      $value         The value that should be validated
-     * @param Constraint $constraint    The constraint for the validation
+     * @param mixed      $value      The value that should be validated
+     * @param Constraint $constraint The constraint for the validation
      */
     public function validate(mixed $value, Constraint $constraint): void
     {

--- a/templates/fields.html.twig
+++ b/templates/fields.html.twig
@@ -8,7 +8,8 @@
                 }
             }) }}
             {{ form_errors(form) }}
-        {% else %}
+        {% endif %}
+        {% if not use_asset_mapper %}
             <script async defer src="{{ js_path }}" type="module"></script>
         {% endif %}
         <altcha-widget

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -29,6 +29,9 @@ class ConfigurationTest extends TestCase
         $this->assertArrayHasKey('use_stimulus', $config);
         $this->assertNull($config['use_stimulus']);
 
+        $this->assertArrayHasKey('use_asset_mapper', $config);
+        $this->assertNull($config['use_asset_mapper']);
+
         $this->assertArrayHasKey('hide_logo', $config);
         $this->assertFalse($config['hide_logo']);
 
@@ -40,6 +43,5 @@ class ConfigurationTest extends TestCase
 
         $this->assertArrayHasKey('hmacKey', $config);
         $this->assertNotNull($config['hmacKey']);
-
     }
 }

--- a/tests/Type/AltchaTypeTest.php
+++ b/tests/Type/AltchaTypeTest.php
@@ -29,6 +29,7 @@ class AltchaTypeTest extends TestCase
             enable: true,
             floating: true,
             useStimulus: true,
+            useAssetMapper: false,
             hideLogo: true,
             hideFooter: true,
             jsPath: "test",


### PR DESCRIPTION
Script tag as it is now is not compatible with several altcha fields on one page - rely on importmap when asset mapper is installed