### PR TITLE
bugfix: widget block is not responsible of displaying form errors

### DIFF
--- a/templates/fields.html.twig
+++ b/templates/fields.html.twig
@@ -7,7 +7,6 @@
                     'data-huluti--altcha-bundle--altcha-target':'input',
                 }
             }) }}
-            {{ form_errors(form) }}
         {% endif %}
         {% if not use_asset_mapper %}
             <script async defer src="{{ js_path }}" type="module"></script>


### PR DESCRIPTION
The form_widget() should not include any form_errors(), or we will get duplicated display https://symfony.com/doc/current/form/form_customization.html#form-rendering-functions