### PR TITLE
Allow null value for i18npath to be more flexible in configuration

### DIFF
--- a/src/Type/AltchaType.php
+++ b/src/Type/AltchaType.php
@@ -22,7 +22,7 @@ class AltchaType extends AbstractType
         private readonly bool $hideLogo,
         private readonly bool $hideFooter,
         private readonly string $jsPath,
-        private readonly string $i18nPath,
+        private readonly ?string $i18nPath,
         private readonly bool $useSentinel,
         private readonly ?string $challengeUrl = null,
     ) {

--- a/templates/fields.html.twig
+++ b/templates/fields.html.twig
@@ -10,7 +10,9 @@
         {% endif %}
         {% if not use_asset_mapper %}
             <script async defer src="{{ js_path }}" type="module"></script>
-            <script async defer src="{{ i18n_path }}" type="module"></script>
+            {% if i18n_path is not null %}
+                <script async defer src="{{ i18n_path }}" type="module"></script>
+            {% endif %}
         {% endif %}
         <altcha-widget
                 data-huluti--altcha-bundle--altcha-target="altcha"


### PR DESCRIPTION
Resubmit of #36 which keeps the default value, but allows null values for setups not needing a separate i18n script