### PR TITLE
sentinel: use the RequestInit into the custom fetch

### DIFF
--- a/templates/fields.html.twig
+++ b/templates/fields.html.twig
@@ -29,11 +29,11 @@
     {% endif %}
     {% if use_sentinel %}
     <script>
-        async function altchaChallengeFetchWithFallback(url) {
+        async function altchaChallengeFetchWithFallback(url, init) {
             try {
-                return await fetch(url);
+                return await fetch(url, init);
             } catch (e) {
-                return await fetch("{{ path('altcha_challenge') }}");
+                return await fetch("{{ path('altcha_challenge') }}", init);
             }
           };
     </script>


### PR DESCRIPTION
Initially it was not required, but since https://github.com/altcha-org/altcha/issues/107 this function is also used to call the verify API, using a POST call with arguments.

Initial implementation at https://github.com/tito10047/altcha-bundle/pull/29