### PR TITLE
Fallback to main request when current request doesn't have a value

### DIFF
--- a/src/Validator/AltchaSentinelValidator.php
+++ b/src/Validator/AltchaSentinelValidator.php
@@ -51,6 +51,11 @@ final class AltchaSentinelValidator extends ConstraintValidator implements Logge
             $value = $request?->request->get('altcha');
         }
 
+        if (!$value) {
+            $request = $this->requestStack->getMainRequest();
+            $value = $request?->request->get('altcha');
+        }
+
         if (!is_string($value)) {
             $this->context->buildViolation($constraint->message)
                 ->addviolation();

--- a/src/Validator/AltchaValidator.php
+++ b/src/Validator/AltchaValidator.php
@@ -35,6 +35,11 @@ final class AltchaValidator extends ConstraintValidator
             $value = $request?->request->get('altcha');
         }
 
+        if (!$value) {
+            $request = $this->requestStack->getMainRequest();
+            $value = $request?->request->get('altcha');
+        }
+
         if (!is_string($value)) {
             $this->context->buildViolation($constraint->message)
                 ->addviolation();


### PR DESCRIPTION
As per title, sometimes you need to use the main request to retrieve the altcha value from the request.

We have this scenario where the form is rendered as a sub request from a template, like this:

```twig
{{ render(controller('App\\Controller\\RegistrationController::register')) }}
```

Without either copying the main request content to the current request or the change I'm proposing here, the automatic validation of the altcha always fails. Test has been update to validate the new path as well.