### PR TITLE
use a dedicated http client for altcha sentinel

### DIFF
--- a/config/services_sentinel.yml
+++ b/config/services_sentinel.yml
@@ -1,4 +1,12 @@
 services:
+  altcha.sentinel.http_client:
+    class: Symfony\Component\HttpClient\HttpClient
+    constructor: 'create'
+    arguments:
+      $defaultOptions:
+        base_uri: '%altcha.sentinel.base_url%'
+    tags: ['http_client.client']
+
   altcha.sentinel.validator:
     class: Tito10047\AltchaBundle\Validator\AltchaSentinelValidator
     tags: ['validator.constraint_validator']
@@ -6,7 +14,7 @@ services:
       $enable: '%altcha.enable%'
       $apiKey: '%altcha.sentinel.api_key%'
       $verifySignatureUrl: '%altcha.sentinel.verify_signature_url%'
-      $httpClient: '@Symfony\Contracts\HttpClient\HttpClientInterface'
+      $httpClient: '@altcha.sentinel.http_client'
       $requestStack: '@request_stack'
       $hmacKey: '%altcha.hmacKey%'
     calls:

--- a/src/DependencyInjection/AltchaExtension.php
+++ b/src/DependencyInjection/AltchaExtension.php
@@ -82,10 +82,7 @@ class AltchaExtension extends Extension implements PrependExtensionInterface
                 $sentinelConfig['api_key']
             ));
             /* @see https://altcha.org/docs/v2/server-integration/ */
-            $container->setParameter('altcha.sentinel.verify_signature_url', sprintf(
-                '%s/v1/verify/signature',
-                $sentinelConfig['base_url']
-            ));
+            $container->setParameter('altcha.sentinel.verify_signature_url', '%s/v1/verify/signature');
         } else {
             $container->setParameter('altcha.sentinel.challenge_url', null);
         }


### PR DESCRIPTION
Register a new Symfony Scoped Http Client: user can then implement their retry failure strategy, dedicated to that client.